### PR TITLE
Fix uncollate when key is empty dict

### DIFF
--- a/deep_helpers/data/helpers.py
+++ b/deep_helpers/data/helpers.py
@@ -91,6 +91,7 @@ def is_multidim_tensor(data: Any) -> bool:
 
 def uncollate(batch: D, batch_size: Optional[int] = None) -> Iterator[D]:
     r"""Uncollates a batch dictionary into an iterator of example dictionaries.
+
     This is the inverse of :func:`collate_fn`. Non-sequence elements are repeated
     for each example in the batch. If examples in the batch have different
     sequence lengths, the iterator will be truncated to the shortest sequence. If length-1
@@ -100,6 +101,7 @@ def uncollate(batch: D, batch_size: Optional[int] = None) -> Iterator[D]:
     Args:
         batch: The batch dictionary to uncollate.
         batch_size: The batch size. If not provided, the batch size is inferred from ``batch``.
+
     Returns:
         An iterator of example dictionaries.
     """
@@ -118,7 +120,7 @@ def uncollate(batch: D, batch_size: Optional[int] = None) -> Iterator[D]:
     elif not lengths and any(isinstance(v, Tensor) and v.numel() for v in sequences.values()):
         _batch_size = 1
     else:
-        _batch_size = min(lengths.values(), default=0)
+        _batch_size = min(lengths.values(), default=batch_size if batch_size is not None else 0)
 
     # Check the batch size against the user-provided batch size
     if batch_size is not None:
@@ -131,9 +133,10 @@ def uncollate(batch: D, batch_size: Optional[int] = None) -> Iterator[D]:
     else:
         batch_size = _batch_size
 
-    # Expand any length-1 sequences to the batch size
+    # Expand any trival sequences to the batch size
     # and slice any sequences that are longer than the batch size to the batch size
     for k, v in sequences.items():
+        # Tensors are expanded / clipped to the batch size as needed
         if isinstance(v, Tensor) and v.numel():
             sequences[k] = (
                 v.view(1).expand(batch_size)
@@ -142,8 +145,13 @@ def uncollate(batch: D, batch_size: Optional[int] = None) -> Iterator[D]:
                 if v.shape[0] <= batch_size
                 else v[:batch_size]
             )
+        # Length 1 sequences are expanded to the batch size
         elif len(v) == 1:
             sequences[k] = list(v) * batch_size
+        # Length 0 sequences will appear in each yielded output as an empty sequence
+        # of the same type
+        elif len(v) == 0:
+            sequences[k] = [v] * batch_size
 
     # repeat non-sequence and non-dict elements
     non_sequences = {

--- a/tests/test_data/test_data_helpers.py
+++ b/tests/test_data/test_data_helpers.py
@@ -120,6 +120,28 @@ class TestUncollate:
         assert (result[0]["t2"] == batch["t2"][0]).all()
         assert (result[1]["t2"] == batch["t2"][1]).all()
 
+    @pytest.mark.parametrize(
+        "struct,batch_size,exp",
+        [
+            ({}, None, 0),
+            ({}, 4, 4),
+        ],
+    )
+    def test_empty_dict(self, struct, batch_size, exp):
+        result = list(uncollate(struct, batch_size))
+        assert len(result) == exp
+
+    def test_key_is_empty_dict(self):
+        batch = {"t1": torch.rand(1, 2), "t2": torch.rand(4, 2), "t3": {}}
+        result = list(uncollate(batch))
+        assert len(result) == 4
+
+    def test_nested_empty_keys(self):
+        batch = {"t1": torch.rand(1, 2), "t2": torch.rand(4, 2), "t3": {"foo": []}}
+        result = list(uncollate(batch))
+        assert len(result) == 4
+        assert all(r["t3"] == {"foo": []} for r in result)
+
 
 class TestDatasetNames:
     @pytest.fixture


### PR DESCRIPTION
When inputs to `uncollate` are dicts with empty subkeys the subkeys will now be broadcasted according to the given or inferred batch size.